### PR TITLE
Updates to fix errors, improve Windows support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -4,6 +4,9 @@ module.exports =
 
   check_syntax: ->
     editor = atom.workspace.getActiveTextEditor()
+    if !(editor.buffer.file?.path?.length > 0)
+        alert('Current file must be saved somewhere before checking its syntax')
+        return
     editor.buffer.save()
     fs = require 'fs'
     path = require 'path'

--- a/index.coffee
+++ b/index.coffee
@@ -6,11 +6,16 @@ module.exports =
     editor = atom.workspace.getActiveTextEditor()
     editor.buffer.save()
     fs = require 'fs'
+    path = require 'path'
     lassocPath = '/usr/bin/lassoc'
+    compilerOutput = '/dev/null'
+    if (process.platform == 'win32')
+        lassocPath = path.join(process.env.LASSO9_HOME, 'LassoExecutables', 'lassoc.exe')
+        compilerOutput = path.join(process.env.TMP, 'atom-language-lasso-compiler-output')
     if !(fs.existsSync(lassocPath))
         alert('Lasso does not appear to be installed on this system; cannot validate syntax')
     else
-        require("child_process").execFile(lassocPath, [editor.buffer.file.path, '-n', '-o', '/dev/null'],
+        require("child_process").execFile(lassocPath, [editor.buffer.file.path, '-n', '-o', compilerOutput],
           (error, stdout, stderr) ->
             if(stderr and stderr.length > 0)
               parsed = stderr.match(/line: (\d+), col: (\d+)\s*$/)

--- a/index.coffee
+++ b/index.coffee
@@ -1,9 +1,9 @@
 module.exports =
   activate: ->
-    atom.commands.add 'atom-workspace', "language-lasso:check_syntax", => @check_syntax()
+    atom.commands.add 'atom-workspace', "language-lasso:check_syntax": => @check_syntax()
 
   check_syntax: ->
-    editor = atom.workspace.getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
     editor.buffer.save()
     require("child_process").execFile('/usr/bin/lassoc', [editor.buffer.file.path, '-n', '-o', '/dev/null'],
       (error, stdout, stderr) ->

--- a/index.coffee
+++ b/index.coffee
@@ -5,16 +5,21 @@ module.exports =
   check_syntax: ->
     editor = atom.workspace.getActiveTextEditor()
     editor.buffer.save()
-    require("child_process").execFile('/usr/bin/lassoc', [editor.buffer.file.path, '-n', '-o', '/dev/null'],
-      (error, stdout, stderr) ->
-        if(stderr and stderr.length > 0)
-          parsed = stderr.match(/line: (\d+), col: (\d+)\s*$/)
-          if(parsed)
-            row    = parseInt(parsed[1]) - 1
-            col    = parseInt(parsed[2]) - 1
-            editor.setCursorBufferPosition([row, col])
+    fs = require 'fs'
+    lassocPath = '/usr/bin/lassoc'
+    if !(fs.existsSync(lassocPath))
+        alert('Lasso does not appear to be installed on this system; cannot validate syntax')
+    else
+        require("child_process").execFile(lassocPath, [editor.buffer.file.path, '-n', '-o', '/dev/null'],
+          (error, stdout, stderr) ->
+            if(stderr and stderr.length > 0)
+              parsed = stderr.match(/line: (\d+), col: (\d+)\s*$/)
+              if(parsed)
+                row    = parseInt(parsed[1]) - 1
+                col    = parseInt(parsed[2]) - 1
+                editor.setCursorBufferPosition([row, col])
 
-          alert(stderr)
-        else
-          alert('No problems found')
-    )
+              alert(stderr)
+            else
+              alert('No problems found')
+        )


### PR DESCRIPTION
Fixed issue #1, and immediately ran into another error, so fixed that as well.

Added some validation to check that `lassoc` exists, and to make sure that the current buffer has been saved somewhere previously. The latter is done since the syntax validation is done by saving the current buffer to disk, and then calling `lassoc` and pointing it to the file.

Adjusted the file paths used for `lassoc` and `/dev/null` to point to appropriate locations when running on Windows.
